### PR TITLE
Add global styles and Vuetify theme

### DIFF
--- a/frontend/src/assets/styles.css
+++ b/frontend/src/assets/styles.css
@@ -1,0 +1,16 @@
+body {
+  margin: 0;
+  font-family: 'Roboto', sans-serif;
+  background-color: #f5f5f5;
+  color: #333;
+  line-height: 1.6;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-weight: 500;
+  margin-top: 0;
+}
+
+p {
+  margin: 0 0 1em;
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4,6 +4,7 @@ import router from './router';
 import store from './store';
 import vuetify from './plugins/vuetify';
 import toasted from 'vue-toasted';
+import './assets/styles.css';
 
 const app = createApp(App);
 app.use(router);

--- a/frontend/src/plugins/vuetify.js
+++ b/frontend/src/plugins/vuetify.js
@@ -1,4 +1,18 @@
 import { createVuetify } from 'vuetify';
 import 'vuetify/styles';
 
-export default createVuetify({});
+export default createVuetify({
+  theme: {
+    defaultTheme: 'customLight',
+    themes: {
+      customLight: {
+        dark: false,
+        colors: {
+          primary: '#1976D2',
+          secondary: '#424242',
+          accent: '#82B1FF'
+        }
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add base typography and background styles
- include global CSS in the main entry
- configure a light Vuetify theme with primary, secondary and accent colors

## Testing
- `npm run build` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a701ce24832eb098c478c2bfb184