### PR TITLE
Implement Vuetify baseline layout

### DIFF
--- a/frontend/src/components/Footer.vue
+++ b/frontend/src/components/Footer.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-footer color="primary" dark>
+  <v-footer app color="primary" dark>
     <span class="mx-auto">&copy; 2024 SIGEM</span>
   </v-footer>
 </template>

--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -1,5 +1,6 @@
 <template>
   <v-app-bar color="primary" dark>
+    <v-app-bar-nav-icon @click="$emit('toggle-drawer')" />
     <v-toolbar-title>Sistema de Gestão do Núcleo de Multas - SIGEM</v-toolbar-title>
     <v-spacer></v-spacer>
     <v-menu v-if="user" offset-y>

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -11,8 +11,21 @@
 <script>
 export default {
   name: 'AppSidebar',
-  data() {
-    return { drawer: false };
+  props: {
+    modelValue: {
+      type: Boolean,
+      required: true
+    }
+  },
+  computed: {
+    drawer: {
+      get() {
+        return this.modelValue;
+      },
+      set(val) {
+        this.$emit('update:modelValue', val);
+      }
+    }
   }
 };
 </script>

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -1,13 +1,15 @@
 <template>
   <v-app>
-    <div class="grid-layout">
-      <AppHeader :user="user" @logout="logout" class="header" />
-      <AppSidebar class="sidebar" />
-      <v-main class="content">
-        <slot />
-      </v-main>
-      <AppFooter class="footer" />
-    </div>
+    <AppSidebar v-model="drawer" />
+    <AppHeader
+      :user="user"
+      @logout="logout"
+      @toggle-drawer="drawer = !drawer"
+    />
+    <v-main>
+      <slot />
+    </v-main>
+    <AppFooter />
   </v-app>
 </template>
 
@@ -20,6 +22,11 @@ import { mapState } from 'vuex';
 export default {
   name: 'MainLayout',
   components: { AppHeader, AppFooter, AppSidebar },
+  data() {
+    return {
+      drawer: false
+    };
+  },
   computed: {
     ...mapState(['user'])
   },
@@ -31,32 +38,3 @@ export default {
   }
 };
 </script>
-
-<style scoped>
-.grid-layout {
-  display: grid;
-  min-height: 100vh;
-  grid-template-rows: auto 1fr auto;
-  grid-template-columns: 220px 1fr;
-  grid-template-areas:
-    "header header"
-    "sidebar content"
-    "footer footer";
-}
-
-.header {
-  grid-area: header;
-}
-
-.sidebar {
-  grid-area: sidebar;
-}
-
-.content {
-  grid-area: content;
-}
-
-.footer {
-  grid-area: footer;
-}
-</style>


### PR DESCRIPTION
## Summary
- switch layout to Vuetify baseline wireframe
- toggle the navigation drawer from the header
- allow sidebar drawer state via `v-model`
- pin footer using `v-footer app`

## Testing
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_6848c2447ed4832e913e2c4632f75cdb