### PR TITLE
Add user registration feature

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -19,3 +19,8 @@ source .venv/bin/activate
 pip install -r requirements.txt
 uvicorn app.main:app --reload
 ```
+
+## API
+
+- `POST /auth/register` – create a new user with `username` and `password`
+- `POST /auth/login` – obtain a token using credentials

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -1,8 +1,18 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
+
+users = {}
 
 router = APIRouter()
 
+@router.post('/register')
+def register(username: str, password: str):
+    if username in users:
+        raise HTTPException(status_code=400, detail="User already exists")
+    users[username] = password
+    return {"message": "registered"}
+
 @router.post('/login')
 def login(username: str, password: str):
-    # TODO: implement authentication
-    return {"token": "dummy"}
+    if users.get(username) != password:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    return {"token": username}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -21,3 +21,9 @@ Install dependencies and run the development server:
 npm install
 npm run serve
 ```
+
+## Routes
+
+- `/login` – página de autenticação
+- `/register` – cadastro de usuário
+- `/` – página inicial

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,9 +1,11 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import Login from '../views/Login.vue';
+import Register from '../views/Register.vue';
 import Home from '../views/Home.vue';
 
 const routes = [
   { path: '/login', component: Login },
+  { path: '/register', component: Register },
   { path: '/', component: Home }
 ];
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: 'http://localhost:8000'
+});
+
+export function registerUser(payload) {
+  return api.post('/auth/register', payload);
+}
+
+export function loginUser(payload) {
+  return api.post('/auth/login', payload);
+}
+
+export default api;

--- a/frontend/src/views/Register.vue
+++ b/frontend/src/views/Register.vue
@@ -42,15 +42,15 @@
                   color="primary"
                   block
                   class="mb-2"
-                  @click="login"
+                  @click="register"
                   :disabled="!formValid"
                 >
-                  Entrar
+                  Cadastrar
                 </v-btn>
 
-                <router-link to="/register">
+                <router-link to="/login">
                   <v-btn color="secondary" variant="text" block>
-                    Criar conta
+                    Já possui conta? Entrar
                   </v-btn>
                 </router-link>
               </v-form>
@@ -68,7 +68,7 @@
 
 <script setup>
 import { ref } from 'vue'
-import { loginUser } from '../services/api'
+import { registerUser } from '../services/api'
 
 const cpf = ref('')
 const senha = ref('')
@@ -84,10 +84,10 @@ const rules = {
   }
 }
 
-function login() {
+function register() {
   if (!formRef.value?.validate()) return
-  loginUser({ username: cpf.value, password: senha.value })
-    .then(() => console.log('logado'))
+  registerUser({ username: cpf.value, password: senha.value })
+    .then(() => console.log('registrado'))
     .catch(err => console.error(err))
 }
 </script>


### PR DESCRIPTION
## Summary
- add in-memory user registry to backend
- implement /auth/register and handle /auth/login
- document API endpoints
- create axios API module for frontend
- add Register view with form and route
- link login to register page
- update frontend docs

## Testing
- `python3 -m pip install -r backend/requirements.txt`
- `pytest`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684968655d94832eb7989d98c2be70e2