### PR TITLE
Add backend setup script

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -11,12 +11,11 @@ Python backend using FastAPI for scraping with session management and authentica
 
 ## Development
 
-Create a virtual environment, install dependencies, and run the application:
+Create a virtual environment, install dependencies, and run the application.
+The `setup.sh` script prepares the environment for you:
 
 ```bash
-python -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
+./setup.sh
 uvicorn app.main:app --reload
 ```
 

--- a/backend/setup.sh
+++ b/backend/setup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- make setup.sh to automate Python env setup
- show setup script usage in backend README

## Testing
- `./setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_68497c607184832eb9a7ef448001f8ee