### PR TITLE
Switch backend from FastAPI to Flask

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 This repository contains the frontend and backend code for the Sigem 2.0 project.
 
 - **frontend/** – Vue 3 SPA using Vuetify, Vue Router, Vuex, Axios and Vue-toasted.
-- **backend/** – FastAPI application for scraping with session management and authentication.
+- **backend/** – Flask application for scraping with session management and authentication.
 
 Each folder includes a README with setup instructions.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,10 +1,10 @@
 # Backend
 
-Python backend using FastAPI for scraping with session management and authentication.
+Python backend using Flask for scraping with session management and authentication.
 
 ## Structure
 
-- **app/main.py** – FastAPI application instance
+- **app/main.py** – Flask application instance
 - **app/auth/** – authentication routes and utilities
 - **app/scraper/** – scraping logic using `requests`
 - **requirements.txt** – Python package requirements
@@ -17,7 +17,7 @@ Create a virtual environment, install dependencies, and run the application:
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
-uvicorn app.main:app --reload
+flask --app app.main run --debug
 ```
 
 ## API

--- a/backend/app/auth/__init__.py
+++ b/backend/app/auth/__init__.py
@@ -1,2 +1,3 @@
-from .router import router
-__all__ = ['router']
+from .router import auth_bp
+
+__all__ = ["auth_bp"]

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -1,18 +1,30 @@
-from fastapi import APIRouter, Depends, HTTPException
+from flask import Blueprint, request, abort, jsonify
 
 users = {}
 
-router = APIRouter()
+auth_bp = Blueprint('auth', __name__)
 
-@router.post('/register')
-def register(username: str, password: str):
+
+@auth_bp.route('/register', methods=['POST'])
+def register():
+    data = request.get_json(silent=True) or request.form
+    username = data.get('username')
+    password = data.get('password')
+    if not username or not password:
+        abort(400, description="username and password required")
     if username in users:
-        raise HTTPException(status_code=400, detail="User already exists")
+        abort(400, description="User already exists")
     users[username] = password
-    return {"message": "registered"}
+    return jsonify(message="registered")
 
-@router.post('/login')
-def login(username: str, password: str):
+
+@auth_bp.route('/login', methods=['POST'])
+def login():
+    data = request.get_json(silent=True) or request.form
+    username = data.get('username')
+    password = data.get('password')
+    if not username or not password:
+        abort(400, description="username and password required")
     if users.get(username) != password:
-        raise HTTPException(status_code=401, detail="Invalid credentials")
-    return {"token": username}
+        abort(401, description="Invalid credentials")
+    return jsonify(token=username)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,12 +1,14 @@
-from fastapi import FastAPI
-from .auth import router as auth_router
-from .scraper import router as scraper_router
+from flask import Flask, jsonify
+from .auth import auth_bp
+from .scraper import scraper_bp
 
-app = FastAPI(title="Sigem Scraper API")
 
-app.include_router(auth_router, prefix="/auth")
-app.include_router(scraper_router, prefix="/scraper")
+app = Flask(__name__)
 
-@app.get("/")
+app.register_blueprint(auth_bp, url_prefix="/auth")
+app.register_blueprint(scraper_bp, url_prefix="/scraper")
+
+
+@app.route("/")
 def read_root():
-    return {"message": "Sigem 2.0 backend"}
+    return jsonify(message="Sigem 2.0 backend")

--- a/backend/app/scraper/__init__.py
+++ b/backend/app/scraper/__init__.py
@@ -1,2 +1,3 @@
-from .router import router
-__all__ = ['router']
+from .router import scraper_bp
+
+__all__ = ["scraper_bp"]

--- a/backend/app/scraper/router.py
+++ b/backend/app/scraper/router.py
@@ -1,8 +1,13 @@
-from fastapi import APIRouter, Depends
+from flask import Blueprint, request, jsonify, abort
 from .tasks import scrape_page
 
-router = APIRouter()
+scraper_bp = Blueprint('scraper', __name__)
 
-@router.get('/')
-def scrape(url: str):
-    return scrape_page(url)
+
+@scraper_bp.route('/', methods=['GET'])
+def scrape():
+    url = request.args.get('url')
+    if not url:
+        abort(400, description="url parameter required")
+    result = scrape_page(url)
+    return jsonify(result)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,2 @@
-fastapi
-uvicorn
+Flask
 requests


### PR DESCRIPTION
## Summary
- replace FastAPI with Flask
- convert auth/scraper routers to Blueprints
- expose new Blueprint names through `__init__`
- update docs and dependencies for Flask

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68497c55614c832eb9c8835099d8bf7f